### PR TITLE
Use git shallow clone to improve cloning performance

### DIFF
--- a/AIDungeon_2.ipynb
+++ b/AIDungeon_2.ipynb
@@ -45,7 +45,7 @@
         "colab": {}
       },
       "source": [
-        "!git clone --depth 1 https://github.com/nickwalton/AIDungeon/\n",
+        "!git clone --depth 1 --branch master https://github.com/nickwalton/AIDungeon/\n",
         "%cd AIDungeon\n",
         "!./install.sh\n",
         "from IPython.display import clear_output \n",

--- a/AIDungeon_2.ipynb
+++ b/AIDungeon_2.ipynb
@@ -45,7 +45,7 @@
         "colab": {}
       },
       "source": [
-        "!git clone https://github.com/nickwalton/AIDungeon/\n",
+        "!git clone --depth 1 https://github.com/nickwalton/AIDungeon/\n",
         "%cd AIDungeon\n",
         "!./install.sh\n",
         "from IPython.display import clear_output \n",


### PR DESCRIPTION
When the repo grows bigger cloning can take a long time. Using shallow cloning will improve perfomance.