### PR TITLE
Use a torrent file to spread the load.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ else
     apt-get install aria2 unzip > /dev/null
     wget "${MODEL_TORRENT_URL}"
     unzip "${MODEL_TORRENT_BASENAME}"
-    aria2c -x 16 -s 32 "${MODEL_TORRENT_BASENAME%.*}"
+    aria2c -x 16 -s 32 --seed-time=0 "${MODEL_TORRENT_BASENAME%.*}"
     echo "Download Complete!"
     cd ../../../..
     pip install -r requirements.txt > /dev/null

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,14 @@
+#!/bin/bash
+cd "$(dirname "${0}")"
+BASE_DIR="$(pwd)"
+
 MODELS_DIRECTORY=generator/gpt2/models
 MODEL_VERSION=model_v5
 MODEL_NAME=model-550
 MODEL_TORRENT_URL="https://github.com/nickwalton/AIDungeon/files/3935881/model_v5.torrent.zip"
 MODEL_TORRENT_BASENAME="$(basename "${MODEL_TORRENT_URL}")"
 
-if [ -d "${MODELS_DIRECTORY}/${MODEL_VERSION}" ]; then
+if [[ -d "${MODELS_DIRECTORY}/${MODEL_VERSION}" ]]; then
     echo "AIDungeon2 is already installed"
 else
     echo "Downloading AIDungeon2 Model... (this may take a few minutes)"
@@ -16,6 +20,6 @@ else
     unzip "${MODEL_TORRENT_BASENAME}"
     aria2c -x 16 -s 32 --seed-time=0 "${MODEL_TORRENT_BASENAME%.*}"
     echo "Download Complete!"
-    cd ../../../..
+    cd "${BASE_DIR}"
     pip install -r requirements.txt > /dev/null
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,26 +1,21 @@
 MODELS_DIRECTORY=generator/gpt2/models
 MODEL_VERSION=model_v5
 MODEL_NAME=model-550
-DOWNLOAD_URL=http://130.211.31.182:80
+MODEL_TORRENT_URL="https://github.com/nickwalton/AIDungeon/files/3935881/model_v5.torrent.zip"
+MODEL_TORRENT_BASENAME="$(basename "${MODEL_TORRENT_URL}")"
 
 if [ -d "${MODELS_DIRECTORY}/${MODEL_VERSION}" ]; then
     echo "AIDungeon2 is already installed"
-
 else
-	echo "Downloading AIDungeon2 Model... (this may take a few minutes)"
-    cd ${MODELS_DIRECTORY}
-    mkdir ${MODEL_VERSION}
-    cd ${MODEL_VERSION}
-    apt-get install aria2 > /dev/null
-    aria2c -x 16 -s 32 "${DOWNLOAD_URL}/${MODEL_VERSION}/${MODEL_NAME}.data-00000-of-00001"
-    wget "${DOWNLOAD_URL}/${MODEL_VERSION}/checkpoint" > /dev/null
-    wget "${DOWNLOAD_URL}/${MODEL_VERSION}/encoder.json" > /dev/null
-    wget "${DOWNLOAD_URL}/${MODEL_VERSION}/hparams.json" > /dev/null
-    wget "${DOWNLOAD_URL}/${MODEL_VERSION}/${MODEL_NAME}.index" > /dev/null
-    wget "${DOWNLOAD_URL}/${MODEL_VERSION}/${MODEL_NAME}.meta" > /dev/null
-    wget "${DOWNLOAD_URL}/${MODEL_VERSION}/vocab.bpe" > /dev/null
+    echo "Downloading AIDungeon2 Model... (this may take a few minutes)"
+    mkdir -p "${MODELS_DIRECTORY}"
+    cd "${MODELS_DIRECTORY}"
+    mkdir "${MODEL_VERSION}"
+    apt-get install aria2 unzip > /dev/null
+    wget "${MODEL_TORRENT_URL}"
+    unzip "${MODEL_TORRENT_BASENAME}"
+    aria2c -x 16 -s 32 "${MODEL_TORRENT_BASENAME%.*}"
     echo "Download Complete!"
     cd ../../../..
-
     pip install -r requirements.txt > /dev/null
 fi


### PR DESCRIPTION
I am directly referencing the torrent file from Issue #39 because downloading using a torrent file is faster than using a magnet.

Enjoy a free data hosting. One side effect is that it's going to be a pain to update with new models.

:+1: 

**P.S.** I have only tested the download part, I have not tested the whole thing.