### PR TITLE
install.sh: use shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 MODELS_DIRECTORY=generator/gpt2/models
 MODEL_VERSION=model_v5
 MODEL_NAME=model-550


### PR DESCRIPTION
The install instructions suggest calling `./install.sh`, but the script doesn't have a shebang to pick an interpreter.