### PR TITLE
Update install.sh to only use sudo if the user is not root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Formal grammars for apocalyptic setting: scavenger, mutant and headhunter contexts/prompts
 - 'Finetune the model yourself' section in README.md
 
+### Fixed
+
+- `install.sh` will only use `sudo` if the user is not root
+
 ## [2.2.0] - 2019-12-19
 
 ### Added
@@ -22,7 +26,7 @@ old `/restart`, saving the old and beginning a brand new game.
 - New content in fantasy grammar.
 - Formal grammars for peasant and rogue contexts/prompts.
 
-## Removed
+### Removed
 
 - F-strings for python 3.4 and 3.5 compatibility
 - Trailing comma in function args for 3.5 compatibility

--- a/install.sh
+++ b/install.sh
@@ -43,19 +43,24 @@ is_command() {
 }
 
 system_package_install() {
+	SUDO=''
+	if (( $EUID != 0 )); then
+		SUDO='sudo'
+	fi
+	
 	PACKAGES=(aria2 git unzip wget)
 	if is_command 'apt-get'; then
-		sudo apt-get install ${PACKAGES[@]}
+		$SUDO apt-get install ${PACKAGES[@]}
 	elif is_command 'brew'; then
 		brew install ${PACKAGES[@]}
 	elif is_command 'yum'; then
-		sudo yum install ${PACKAGES[@]}
+		$SUDO yum install ${PACKAGES[@]}
 	elif is_command 'dnf'; then
-		sudo dnf install ${PACKAGES[@]}
+		$SUDO dnf install ${PACKAGES[@]}
 	elif is_command 'pacman'; then
-		sudo pacman -S ${PACKAGES[@]}
+		$SUDO pacman -S ${PACKAGES[@]}
 	elif is_command 'apk'; then
-		sudo apk --update add ${PACKAGES[@]}
+		$SUDO apk --update add ${PACKAGES[@]}
 	else
 		echo "You do not seem to be using a supported package manager."
 		echo "Please make sure ${PACKAGES[@]} are installed then press [ENTER]"


### PR DESCRIPTION
## 🎉 Issues resolved:

- `install.sh` will only use `sudo` if the user is not root (useful for Docker containers where the user is often root)
- fixed formatting of the "Removed" heading under "[2.2.0] - 2019-12-19" in `CHANGELOG.md`

## 🧪 How to Test

1. Run `install.sh` as the root user
2. Run `install.sh` as a non-root user