### PR TITLE
Add launch argument for using CPU instead of GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Formal grammars for apocalyptic setting: scavenger, mutant and headhunter contexts/prompts
 - 'Finetune the model yourself' section in README.md
+- Command line argument `--cpu` which forces use of the CPU instead of a GPU.
 
 ### Fixed
 

--- a/generator/gpt2/gpt2_generator.py
+++ b/generator/gpt2/gpt2_generator.py
@@ -14,7 +14,7 @@ tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 
 
 class GPT2Generator:
-    def __init__(self, generate_num=60, temperature=0.4, top_k=40, top_p=0.9, censor=True):
+    def __init__(self, generate_num=60, temperature=0.4, top_k=40, top_p=0.9, censor=True, force_cpu=False):
         self.generate_num = generate_num
         self.temp = temperature
         self.top_k = top_k
@@ -35,8 +35,14 @@ class GPT2Generator:
             hparams.override_from_dict(json.load(f))
         seed = np.random.randint(0, 100000)
 
-        config = tf.compat.v1.ConfigProto()
-        config.gpu_options.allow_growth = True
+        config = None
+        if force_cpu:
+            config = tf.compat.v1.ConfigProto(
+                device_count={"GPU": 0}
+            )
+        else:
+            config = tf.compat.v1.ConfigProto()
+            config.gpu_options.allow_growth = True
         self.sess = tf.compat.v1.Session(config=config)
 
         self.context = tf.placeholder(tf.int32, [self.batch_size, None])

--- a/play.py
+++ b/play.py
@@ -3,6 +3,7 @@ import os
 import random
 import sys
 import time
+import argparse
 
 from generator.gpt2.gpt2_generator import *
 from story import grammars
@@ -10,6 +11,13 @@ from story.story_manager import *
 from story.utils import *
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
+parser = argparse.ArgumentParser("Play AIDungeon 2")
+parser.add_argument(
+    "--cpu",
+    action="store_true",
+    help="Force using CPU instead of GPU."
+)
 
 
 def splash():
@@ -146,7 +154,14 @@ def instructions():
     return text
 
 
-def play_aidungeon_2():
+def play_aidungeon_2(args):
+    """
+    Entry/main function for starting AIDungeon 2
+
+    Arguments:
+        args (namespace): Arguments returned by the
+                          ArgumentParser
+    """
 
     console_print(
         "AI Dungeon 2 will save and use your actions and game to continually improve AI Dungeon."
@@ -157,7 +172,7 @@ def play_aidungeon_2():
     upload_story = True
 
     print("\nInitializing AI Dungeon! (This might take a few minutes)\n")
-    generator = GPT2Generator()
+    generator = GPT2Generator(force_cpu=args.cpu)
     story_manager = UnconstrainedStoryManager(generator)
     print("\n")
 
@@ -364,4 +379,5 @@ def play_aidungeon_2():
 
 
 if __name__ == "__main__":
-    play_aidungeon_2()
+    args = parser.parse_args()
+    play_aidungeon_2(args)


### PR DESCRIPTION
## 🎉 Issues resolved:

- closes #146

A simple argument which forces use of CPU instead of trying to load model to a GPU with possibly not enough memory.

This is especially useful on Windows where `CUDA_VISIBLE_DEVICES` environment variable does not work and you have GPU-enabled Tensorflow installed as it is for other purposes.

## 🧪 How to Test

1. Have GPU-enabled Tensorflow installed
2. Launch game with `python play.py --cpu`
3. Game should now only load model to RAM and not touch GPU devices.

## Other comments

Automatic detection is also an option. However this would become brittle if, in future, the model is squeezed into smaller size (which would then fit to e.g. 8GB GPU cards). 
