### PR TITLE
Fix loading saved games from the title splash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `install.sh` will only use `sudo` if the user is not root
+- Fix loading saved games from the title splash to use the new local save path.
 
 ## [2.2.0] - 2019-12-19
 

--- a/story/story_manager.py
+++ b/story/story_manager.py
@@ -180,15 +180,20 @@ class StoryManager:
         return str(self.story)
 
     def load_new_story(self, story_id, upload_story=False):
+        save_path = "./saved_stories/"
         file_name = "story" + story_id + ".json"
-        cmd = "gsutil cp gs://aidungeonstories/" + file_name + " ."
-        os.system(cmd)
-        exists = os.path.isfile(file_name)
+        exists = os.path.isfile(os.path.join(save_path, file_name))
 
         if not exists:
-            return "Error save not found."
+            print("Save not found locally. Trying in the cloud bucket (only valid for saves before Dec 24 2019)")
+            cmd = "gsutil cp gs://aidungeonstories/" + file_name + " " + save_path
+            os.system(cmd)
+            exists = os.path.isfile(os.path.join(save_path, file_name))
 
-        with open(file_name, "r") as fp:
+        if not exists:
+            return "Error save not found locally or on the cloud."
+
+        with open(os.path.join(save_path, file_name), "r") as fp:
             game = json.load(fp)
         self.story = Story("", upload_story=upload_story)
         self.story.init_from_dict(game)


### PR DESCRIPTION
Saved games weren't loading from the title splash. This updates the code
used by the splash to match up with the load method used by the load
command.

## 🎉 Issues resolved:

- closes #223

## 🧪 How to Test

1. Load a saved game from the title, before starting a new game.
2. Game should load properly if it was saved to `./saved_stories/`, where previously loading from the title would only find them in `.` (the current directory).
