### PR TITLE
Fix end punctuation from being chopped off.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `install.sh` will only use `sudo` if the user is not root
 - Fix loading saved games from the title splash to use the new local save path.
+- Fix ending punctuation being chopped off of generated text.
 
 ## [2.2.0] - 2019-12-19
 

--- a/story/utils.py
+++ b/story/utils.py
@@ -132,7 +132,7 @@ def cut_trailing_sentence(text):
     if act_token > 0:
         last_punc = min(last_punc, act_token - 1)
 
-    text = text[:last_punc]
+    text = text[:last_punc+1]
 
     text = cut_trailing_quotes(text)
     text = cut_trailing_action(text)


### PR DESCRIPTION
The `cut_trailing_sentence` function would cut off the ending punctuation,
leaving generated text without an ending punctuation. This change should
fix that.

It may also fix an occasional bug I've seen where the last letter of a word gets cut off, which may be caused by this method chopping off a character too much in certain situations.

Credit goes to Herohtar for posting a bug report identifying the problem and the section of code responsible.

## 🎉 Issues resolved:

- closes #215 

## 🧪 How to Test

Simply play the game. Responses from the AI previously didn't end with punctuation. After this fix, most responses should end in punctuation.

<!-- 

## 📷 Screenshot (optional)

-->
